### PR TITLE
Resplit audience and visibility (pub status)

### DIFF
--- a/app/assets/stylesheets/main_backoffice.scss
+++ b/app/assets/stylesheets/main_backoffice.scss
@@ -178,37 +178,49 @@ span.visibility {
 }
 
 // ---------------------------------------------------------------- new visibility
-.visibility-radios {
+.visibility-container {
+  margin-left: 1em;
   background-color: #fff;
   padding: 4px 4px 0 4px;
   border-radius: 5px;
   box-sizing: border-box;
-  display: inline-block;
-
-  label {
-    padding: 0.05em 0.2em;
-    display: inline-block;
-    margin-right: 0;
-    cursor: pointer;
-    border-bottom: 2px solid #fff;
-    border-radius: 15%;
-    span {
-      transition: transform .2s ease-in-out;
-    }
-    span:hover {
-      top: -0.5ex;
-      transform: scale(1.25);
-      color: var(--red);
-    }
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  span.text {
+    font-size: 60%;
+    // line-height: 60%;
+    // margin-top: -1ex;
+    position: relative;
   }
-  input[type="radio"] {
-    display: none;
-  }
-  input[type="radio"]:checked + label {
-    box-shadow: inset 0 0 2px #666;
-    border-bottom: 2px solid var(--red);
-    span {
-      color: var(--red-dark);
+  .visibility-radios {
+    border-bottom: 1px solid #d9d9d9;
+    label {
+      padding: 0.05em 0.2em;
+      display: inline-block;
+      margin-right: 0;
+      cursor: pointer;
+      border-bottom: 2px solid #fff;
+      border-radius: 15%;
+      span {
+        transition: transform .2s ease-in-out;
+      }
+      span:hover {
+        top: -0.5ex;
+        transform: scale(1.25);
+        color: var(--red);
+      }
+    }
+    input[type="radio"] {
+      display: none;
+    }
+    input[type="radio"]:checked + label {
+      box-shadow: inset 0 0 2px #666;
+      border-bottom: 2px solid var(--red);
+      span {
+        color: var(--red-dark);
+      }
     }
   }
 }

--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -114,7 +114,7 @@ class AwardsController < BackendController
   def award_params
     params.require(:award).permit(
       :location, :title_fr, :title_en, :year, :issuer,
-      :audience, :visible, :position
+      :audience, :visibility, :position
     )
   end
 end

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -90,6 +90,6 @@ class BoxesController < BackendController
 
   # Only allow a list of trusted parameters through.
   def box_params
-    params.require(:box).permit(:audience, :position)
+    params.require(:box).permit(:audience, :visibility, :position)
   end
 end

--- a/app/controllers/educations_controller.rb
+++ b/app/controllers/educations_controller.rb
@@ -114,7 +114,7 @@ class EducationsController < BackendController
   def education_params
     params.require(:education).permit(
       :title_en, :title_fr, :field_en, :field_fr, :director, :school,
-      :year_begin, :year_end, :position, :audience, :visible, :description_fr, :description_en
+      :year_begin, :year_end, :position, :audience, :visibility, :description_fr, :description_en
     )
   end
 end

--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -114,7 +114,7 @@ class ExperiencesController < BackendController
   def experience_params
     params.require(:experience).permit(
       :location, :title_fr, :title_en, :year_begin, :year_end,
-      :audience, :visible, :position, :description_fr, :description_en
+      :audience, :visibility, :position, :description_fr, :description_en
     )
   end
 end

--- a/app/controllers/index_boxes_controller.rb
+++ b/app/controllers/index_boxes_controller.rb
@@ -8,6 +8,6 @@ class IndexBoxesController < BoxesController
 
   # Only allow a list of trusted parameters through.
   def box_params
-    params.require(:index_box).permit(:audience)
+    params.require(:index_box).permit(:audience, :visibility)
   end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -102,6 +102,6 @@ class PublicationsController < ApplicationController
   end
 
   def publication_params
-    params.require(:publication).permit(:title, :journal, :year, :authors, :url, :position, :audience, :visible)
+    params.require(:publication).permit(:title, :journal, :year, :authors, :url, :position, :audience, :visibility)
   end
 end

--- a/app/controllers/rich_text_boxes_controller.rb
+++ b/app/controllers/rich_text_boxes_controller.rb
@@ -9,7 +9,7 @@ class RichTextBoxesController < BoxesController
   # Only allow a list of trusted parameters through.
   def box_params
     params.require(:rich_text_box).permit(
-      :audience,
+      :audience, :visibility,
       :title_fr, :title_en, :content_fr, :content_en
     )
   end

--- a/app/controllers/socials_controller.rb
+++ b/app/controllers/socials_controller.rb
@@ -94,7 +94,7 @@ class SocialsController < ApplicationController
   private
 
   def social_params
-    params.require(:social).permit(:tag, :value, :audience)
+    params.require(:social).permit(:tag, :value, :audience, :visibility)
   end
 
   def set_profile

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -80,29 +80,39 @@ module ProfilesHelper
     safe_join(content)
   end
 
-  AUDIENCE_OPTIONS = [
-    { label: 'public', icon: 'globe' },
-    { label: 'intranet', icon: 'home' },
-    # {label: 'authenticated', icon: 'key'},
-    # {label: 'owner', icon: 'user-check'},
-    { label: 'authenticated', icon: 'user-check' },
-    { label: 'owner', icon: 'edit-3' },
-    { label: 'hidden', icon: 'eye-off' }
-  ].freeze
-
   def audience_selector(form, with_stimulus: false)
-    id0 = "#{form.object_name.underscore}_#{form.object.id}"
+    id0 = "#{form.object_name.underscore}_audience_#{form.object.id}"
     stim_data = { action: "input->visibility#onChange", "visibility-target": "radio" }
     content = []
-    AUDIENCE_OPTIONS.each_with_index do |o, i|
+    AudienceLimitable::AUDIENCE_OPTIONS.each_with_index do |o, i|
       id = "#{id0}_#{i}"
+      label_data = { label: form.object.audience_label(i) }
       title = t "visibility.labels.#{o[:label]}"
       content << if with_stimulus
-                   form.radio_button(:audience, i, id: id, data: stim_data)
+                   form.radio_button(:audience, i, id: id, data: stim_data.merge(label_data))
                  else
-                   form.radio_button(:audience, i, id: id)
+                   form.radio_button(:audience, i, id: id, data: label_data)
                  end
       content << form.label("audience_#{i}".to_sym, tag.span(icon(o[:icon])), for: id, title: title)
+    end
+    content = safe_join(content)
+    tag.div(content, class: "visibility-radios")
+  end
+
+  def visibility_selector(form, with_stimulus: false)
+    id0 = "#{form.object_name.underscore}_visibility_#{form.object.id}"
+    stim_data = { action: "input->visibility#onChange", "visibility-target": "radio" }
+    content = []
+    AudienceLimitable::VISIBILITY_OPTIONS.each_with_index do |o, i|
+      id = "#{id0}_#{i}"
+      label_data = { label: form.object.visibility_label(i) }
+      title = t "visibility.labels.#{o[:label]}"
+      content << if with_stimulus
+                   form.radio_button(:visibility, i, id: id, data: stim_data.merge(label_data))
+                 else
+                   form.radio_button(:visibility, i, id: id, data: label_data)
+                 end
+      content << form.label("visibility_#{i}".to_sym, tag.span(icon(o[:icon])), for: id, title: title)
     end
     content = safe_join(content)
     tag.div(content, class: "visibility-radios")

--- a/app/javascript/controllers/visibility_controller.js
+++ b/app/javascript/controllers/visibility_controller.js
@@ -3,30 +3,33 @@ import { Controller } from "@hotwired/stimulus"
 import { put } from "@rails/request.js";
 
 export default class extends Controller {
-  static values = { model: String };
-  static targets = [ "radio" ];
+  static values = { model: String, field: String };
+  static targets = [ "form", "radio", "label"];
 
   connect() {
     this.oldRadio = this.radioTargets.find((x) => x.checked);
+    this.url = this.formTarget.action;
     this.recovering = false;
   }
 
   onChange() {
     if (this.recovering) {
-      console.log("Recovering");
       this.recovering = false;
       return;
     }
 
     const newRadio = this.radioTargets.find((x) => x.checked);
+
     const value = newRadio.value;
-    const url = this.element.action;
+    const label = newRadio.getAttribute('data-label');
     // JS shit!
     const body = {};
-    body[this.modelValue] = {'audience': value};
-    put(url, {body: body}).then((response) => {
+    body[this.modelValue] = {};
+    body[this.modelValue][this.fieldValue] = value;
+    put(this.url, {body: body}).then((response) => {
       if (response.ok) {
         this.oldRadio = newRadio;
+        this.labelTarget.textContent=label;
       } else {
         // TODO: add flash message on error
         // prevent onChange to fire again

--- a/app/models/concerns/audience_limitable.rb
+++ b/app/models/concerns/audience_limitable.rb
@@ -1,20 +1,37 @@
 # frozen_string_literal: true
 
 # This could be nicely implemented as enum but it is not yet implemented for mysql
+# audience: 0=world, 1=intranet, 2=authenticated user
+# visibility: 0=public, 1=draft, 2=hidden
 # TODO: write unit tests
 # TODO: when importing legacy data:
-#       - visible => audience=0
-#       - hidden  => audience=4
+#       - visible => audience=0, visibility=0
+#       - hidden  => audience=0, visibility=2
+
 module AudienceLimitable
+  AUDIENCE_OPTIONS = [
+    { label: 'public', icon: 'globe' },
+    { label: 'intranet', icon: 'home' },
+    { label: 'authenticated', icon: 'user-check' }
+  ].freeze
+
+  VISIBILITY_OPTIONS = [
+    { label: 'published', icon: 'eye' },
+    { label: 'draft', icon: 'edit-3' },
+    { label: 'hidden', icon: 'eye-off' }
+  ].freeze
+
   extend ActiveSupport::Concern
 
   included do
-    scope :world_visible, -> { where(audience: 0) }
-    scope :intranet_visible, -> { where(audience: 0...2) }
-    scope :auth_visible, -> { where(audience: 0...3) }
-    scope :owner_visible, -> { where(audience: 0...4) }
-    scope :for_audience, ->(audience) { where(audience: 0...(audience + 1)) }
-    validates :audience, numericality: { in: 0...5 }
+    # Reminder: ranges do not include the upper limit
+    scope :world_visible, -> { where(audience: 0, visibility: 0) }
+    scope :intranet_visible, -> { where(audience: 0...2, visibility: 0) }
+    scope :auth_visible, -> { where(audience: 0...3, visibility: 0) }
+    scope :owner_visible, -> { where(visibility: 0...2) }
+    scope :for_audience, ->(audience) { where(audience: 0...(audience + 1), visibility: 0) }
+    validates :audience, numericality: { in: 0...3 }
+    validates :visibility, numericality: { in: 0...3 }
   end
 
   def visible_by?(level = 0)
@@ -22,22 +39,30 @@ module AudienceLimitable
   end
 
   def world_visible?
-    audience.zero?
+    visibilty.zero? && audience.zero?
   end
 
   def intranet_visible?
-    audience < 2
+    visibilty.zero? && audience < 2
   end
 
   def auth_visible?
-    audience < 3
+    visibilty.zero? && audience < 3
   end
 
   def owner_visible?
-    audience < 4
+    visibility != 2
   end
 
   def hidden?
-    audience > 3
+    visibility == 2
+  end
+
+  def visibility_label(v = visibility)
+    VISIBILITY_OPTIONS[v][:label]
+  end
+
+  def audience_label(v = audience)
+    AUDIENCE_OPTIONS[v][:label]
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -56,13 +56,10 @@ class Profile < ApplicationRecord
     show_nationality: false,
     show_phone: true,
     show_photo: false,
-    show_title: false,
     force_lang: nil,
     personal_web_url: nil,
     nationality_en: nil,
     nationality_fr: nil,
-    title_en: nil,
-    title_fr: nil
   }.freeze
 
   def self.new_with_defaults(sciper)

--- a/app/views/awards/_award.json.jbuilder
+++ b/app/views/awards/_award.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.extract! award, :id, :title_en, :title_fr, :issuer, :year,
-              :updated_at, :position, :audience, :visible
+              :updated_at, :position, :audience, :visibility
 
 json.profile profile_url(award.profile, format: :json)
 json.url award_url(award, format: :json)

--- a/app/views/boxes/_box.json.jbuilder
+++ b/app/views/boxes/_box.json.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 json.extract! box, :id, :type, :subkind, :title_en, :title_fr, :show_title, :locked,
-              :updated_at, :position, :audience, :visible
+              :updated_at, :position, :audience, :visibility
 json.profile profile_url(box.profile, format: :json)

--- a/app/views/educations/_education.json.jbuilder
+++ b/app/views/educations/_education.json.jbuilder
@@ -2,6 +2,7 @@
 
 json.extract! education, :id, :field_en, :field_fr, :title_en, :title_fr,
               :year_begin, :year_end, :school, :director,
+              :audience, :visibility,
               :created_at, :updated_at
 json.profile profile_url(education.profile, format: :json)
 json.url education_url(education, format: :json)

--- a/app/views/experiences/_experience.json.jbuilder
+++ b/app/views/experiences/_experience.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 json.extract! experience, :id, :title_en, :title_fr, :location, :year_begin, :year_end, :position, :created_at,
-              :updated_at, :position, :audience
+              :updated_at, :position, :audience, :visibility
 json.profile profile_url(experience.profile, format: :json)
 json.url experience_url(experience, format: :json)

--- a/app/views/publications/_publication.json.jbuilder
+++ b/app/views/publications/_publication.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 json.extract! publication, :id, :title, :url, :authors, :year,
-              :audience, :created_at, :position, :updated_at
+              :audience, :visibility, :created_at, :position, :updated_at
 json.profile profile_url(publication.profile, format: :json)
 json.url publication_url(publication, format: :json)

--- a/app/views/rich_text_boxes/_rich_text_box.json.jbuilder
+++ b/app/views/rich_text_boxes/_rich_text_box.json.jbuilder
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-json.extract! box, :id, :created_at, :updated_at
+json.extract! box, :id, :audience, :visibility, :created_at, :updated_at
 json.url box_url(box, format: :json)

--- a/app/views/shared/_item_actions.html.erb
+++ b/app/views/shared/_item_actions.html.erb
@@ -4,5 +4,7 @@
 <%= link_to icon_text('action.delete', 'trash-2'), send("#{item.class.name.downcase}_path", item), class: "btn btn-secondary btn-sm", method: :delete, data: {turbo_stream: true, turbo_method:'delete', turbo_confirm: t('action.confirm')} %>
 <%= link_to icon_text('action.edit', 'edit'), send("edit_#{item.class.name.downcase}_path", item), class: "btn btn-secondary btn-sm", data: {turbo_stream: true} %>
 </p>
+<!--
 <span class="muted"><%= Award.human_attribute_name(:audience) %>: </span>
-<%= render "shared/item_visibility", item: item %>
+-->
+<%= render "shared/item_visibility", item: item, extra_class: nil %>

--- a/app/views/shared/_item_visibility.html.erb
+++ b/app/views/shared/_item_visibility.html.erb
@@ -1,11 +1,49 @@
-<%= form_with(
-  model: item, 
-  remote: true, 
-  format: 'json',
-  class: defined?(extra_class) ? ["visibility-radios"] + extra_class : ["visibility-radios"],
-  data: {
-    controller: "visibility",
-    "visibility-model-value": item.class.name.underscore,
-  }) do |form| %>
-  <%= audience_selector(form, with_stimulus: true) %>
+<%= tag.div(
+    class: "visibility-container #{extra_class&.join(' ')}",
+    data: {
+      "controller": "visibility",
+      "visibility-model-value": item.class.name.underscore,
+      "visibility-field-value": "visibility"
+    }
+  ) do %>
+  <!-- 
+  <span class="text"><%= t 'title.selector_visibility' %></span> 
+  -->
+  <%= form_with(
+      model: item, 
+      remote: true, 
+      format: 'json',
+      class: ["visibility-radios"],
+      data: {"visibility-target": "form"},
+    ) do |form| %>
+    <%= visibility_selector(form, with_stimulus: true) %>
+  <% end %>
+  <span class="text" data-visibility-target="label">
+    <%= t "visibility.short_labels.#{item.visibility_label}" %>
+  </span>
+<% end %>
+
+<%= tag.div(
+    class: "visibility-container #{extra_class&.join(' ')}",
+    data: {
+      "controller": "visibility",
+      "visibility-model-value": item.class.name.underscore,
+      "visibility-field-value": "audience"
+    }
+  ) do %>
+  <!-- 
+  <span class="text"><%= t 'title.selector_audience' %></span>
+  -->
+  <%= form_with(
+      model: item, 
+      remote: true, 
+      format: 'json',
+      class: ["visibility-radios"],
+      data: {"visibility-target": "form"},
+    ) do |form| %>
+    <%= audience_selector(form, with_stimulus: true) %>
+  <% end %>
+  <span class="text" data-visibility-target="label">
+    <%= t "visibility.short_labels.#{item.audience_label}" %>
+  </span>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,8 @@ en:
     of: "of"
     past_phd_students: "Past EPFL PhD Students"
     publications: "Publications"
+    selector_audience: "Access"
+    selector_visibility: "Status"
     research: "Research"
     teaching: "Teaching & PhD"
     work_experience: "Work Experience"
@@ -206,12 +208,22 @@ en:
     intranet: "intranet only"
     intranet_access: "intranet"
     labels:
-      authenticated: "Authenticated users only"
-      draft: "Editor only"
-      owner: "Editor only"
+      published: "Published"
+      draft: "Draft"
       hidden: "Hidden"
+
+      public: "World visible"
       intranet: "Intranet only"
-      public: "Public"
+      authenticated: "Authenticated users only"
+    short_labels:
+      published: "Published"
+      draft: "Draft"
+      hidden: "Hidden"
+
+      public: "World"
+      intranet: "Intranet"
+      authenticated: "Users"
+
     public: "public"
     public_access: "public"
     visible: "visible"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -174,6 +174,8 @@ fr:
     pictures: "Photos de profil"
     publications: "Publications"
     research: "Recherche"
+    selector_audience: "Access"
+    selector_visibility: "Status"
     teaching: "Enseignement"
     teaching_domain: "Domaine d'enseignement"
     work_experience: "Parcours professionnel"
@@ -187,13 +189,23 @@ fr:
     hidden_address: "NO address"
     intranet: "Uniquement sur l'intranet"
     intranet_access: "intranet"
+
     labels:
-      authenticated: "Utilisateurs de l'EPFL"
+      published: "Publié"
       draft: "Brouillon (éditeur uniquement)"
-      owner: "Éditeur uniquement"
       hidden: "Invisible"
+
+      public: "Depuis partout"
+      intranet: "Intranet Seulement"
+      authenticated: "Utilisateurs de l'EPFL"
+    short_labels:
+      published: "Publié"
+      draft: "Brouillon"
+      hidden: "Invisible"
+
+      public: "Monde"
       intranet: "Intranet"
-      public: "Publique"
+      authenticated: "Personnel"
     public: "Publique"
     public_access: "public"
     visible: "visible"

--- a/db/migrate/20230607102112_create_boxes.rb
+++ b/db/migrate/20230607102112_create_boxes.rb
@@ -27,8 +27,8 @@ class CreateBoxes < ActiveRecord::Migration[7.0]
       t.string     :title_de
       t.boolean    :show_title, default: true
       t.boolean    :locked, default: false
-      t.integer    :audience, default: 0 # 0=public, 1=intranet, 2=authenticated user, 3=me (draft)
-      t.boolean    :visible, default: false
+      t.integer    :audience, default: 0 # 0=public, 1=intranet, 2=authenticated
+      t.integer    :visibility, default: 1 # 0=published, 1=draft, 2=hidden
       t.integer    :position, null: false
       t.text       :data, null: true
       t.timestamps

--- a/db/migrate/20240110081855_create_social.rb
+++ b/db/migrate/20240110081855_create_social.rb
@@ -8,8 +8,8 @@ class CreateSocial < ActiveRecord::Migration[7.0]
       t.string :tag
       t.string :value
       t.integer :position, default: false
-      t.boolean :visible, default: true
-      t.integer :audience, default: 0 # 0=public, 1=intranet, 2=authenticated user, 3=me (draft)
+      t.integer :audience, default: 0 # 0=public, 1=intranet, 2=authenticated
+      t.integer :visibility, default: 1 # 0=published, 1=draft, 2=hidden
       t.timestamps
     end
   end

--- a/db/migrate/20240219110933_create_educations.rb
+++ b/db/migrate/20240219110933_create_educations.rb
@@ -17,8 +17,8 @@ class CreateEducations < ActiveRecord::Migration[7.0]
       t.integer :year_begin, null: true
       t.integer :year_end, null: true
       t.integer :position, null: false
-      t.integer :audience, default: 0 # 0=public, 1=intranet, 2=authenticated user, 3=me (draft), 4=hidden/disabled
-      t.boolean :visible, default: false
+      t.integer    :audience, default: 0 # 0=public, 1=intranet, 2=authenticated
+      t.integer    :visibility, default: 1 # 0=published, 1=draft, 2=hidden
 
       t.timestamps
     end

--- a/db/migrate/20240219111449_create_awards.rb
+++ b/db/migrate/20240219111449_create_awards.rb
@@ -14,8 +14,8 @@ class CreateAwards < ActiveRecord::Migration[7.0]
       t.integer :year
       t.string  :url
       t.integer :position, null: false
-      t.integer :audience, default: 0 # 0=public, 1=intranet, 2=authenticated user, 3=me (draft)
-      t.boolean :visible, default: false
+      t.integer    :audience, default: 0 # 0=public, 1=intranet, 2=authenticated
+      t.integer    :visibility, default: 1 # 0=published, 1=draft, 2=hidden
 
       t.timestamps
     end

--- a/db/migrate/20240219112048_create_experiences.rb
+++ b/db/migrate/20240219112048_create_experiences.rb
@@ -13,8 +13,8 @@ class CreateExperiences < ActiveRecord::Migration[7.0]
       t.integer :year_begin, null: false
       t.integer :year_end, null: true
       t.integer :position, null: false
-      t.integer :audience, default: 0 # 0=public, 1=intranet, 2=authenticated user, 3=me (draft)
-      t.boolean :visible, default: false
+      t.integer    :audience, default: 0 # 0=public, 1=intranet, 2=authenticated
+      t.integer    :visibility, default: 1 # 0=published, 1=draft, 2=hidden
       t.timestamps
     end
     add_index :experiences, %i[profile_id position], unique: true

--- a/db/migrate/20240827110051_create_publications.rb
+++ b/db/migrate/20240827110051_create_publications.rb
@@ -10,8 +10,8 @@ class CreatePublications < ActiveRecord::Migration[7.1]
       t.integer :year, null: false
       t.integer :position, null: false
       t.string :journal, null: false
-      t.integer :audience, default: 0 # 0=public, 1=intranet, 2=authenticated user, 3=me (draft)
-      t.boolean :visible
+      t.integer :audience, default: 0 # 0=public, 1=intranet, 2=authenticated
+      t.integer :visibility, default: 1 # 0=published, 1=draft, 2=hidden
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,7 +89,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_27_110051) do
     t.string "url"
     t.integer "position", null: false
     t.integer "audience", default: 0
-    t.boolean "visible", default: false
+    t.integer "visibility", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_awards_on_category_id"
@@ -111,7 +111,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_27_110051) do
     t.boolean "show_title", default: true
     t.boolean "locked", default: false
     t.integer "audience", default: 0
-    t.boolean "visible", default: false
+    t.integer "visibility", default: 1
     t.integer "position", null: false
     t.text "data"
     t.datetime "created_at", null: false
@@ -151,7 +151,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_27_110051) do
     t.integer "year_end"
     t.integer "position", null: false
     t.integer "audience", default: 0
-    t.boolean "visible", default: false
+    t.integer "visibility", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_id", "position"], name: "index_educations_on_profile_id_and_position", unique: true
@@ -169,7 +169,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_27_110051) do
     t.integer "year_end"
     t.integer "position", null: false
     t.integer "audience", default: 0
-    t.boolean "visible", default: false
+    t.integer "visibility", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_id", "position"], name: "index_experiences_on_profile_id_and_position", unique: true
@@ -244,7 +244,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_27_110051) do
     t.integer "position", null: false
     t.string "journal", null: false
     t.integer "audience", default: 0
-    t.boolean "visible"
+    t.integer "visibility", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_id"], name: "index_publications_on_profile_id"
@@ -288,8 +288,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_27_110051) do
     t.string "tag"
     t.string "value"
     t.integer "position", default: 0
-    t.boolean "visible", default: true
     t.integer "audience", default: 0
+    t.integer "visibility", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_id"], name: "index_socials_on_profile_id"

--- a/test/fixtures/awards.yml
+++ b/test/fixtures/awards.yml
@@ -7,8 +7,8 @@ edo_awa:
   title_en: ACM Software System Award
   title_fr: ACM Software System Award
   url: https://awards.acm.org/software-system
-  visible: true
   audience: 0
+  visibility: 0
   position: 1
 
 gio_awa:
@@ -20,6 +20,6 @@ gio_awa:
   title_en: ACM Software System Award
   title_fr: ACM Software System Award
   url: https://awards.acm.org/software-system
-  visible: true
   audience: 0
+  visibility: 0
   position: 1

--- a/test/fixtures/boxes.yml
+++ b/test/fixtures/boxes.yml
@@ -9,8 +9,8 @@ gio_box_expertise:
   title_fr: Domaines de compétences
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 1
 
 gio_box_education:
@@ -24,8 +24,8 @@ gio_box_education:
   title_fr: Formation
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 2
 
 gio_box_experience:
@@ -38,8 +38,8 @@ gio_box_experience:
   title_fr: Parcours professionnel
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 3
 
 gio_box_publication:
@@ -52,8 +52,8 @@ gio_box_publication:
   title_fr: "Publications Representatives"
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 4
 
 # ---------------------------------------------------------------------- Edouard
@@ -67,8 +67,8 @@ edo_box_awards:
   title_fr: Récompenses
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 4
 
 # ---------------------------------------------------------------------- Olivier
@@ -81,8 +81,8 @@ oli_box_expertise:
   title_fr: Expertise
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 1
 
 oli_box_bio:
@@ -94,8 +94,8 @@ oli_box_bio:
   title_fr: Biographie
   show_title: false
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 2
 
 oli_box_cv:
@@ -107,8 +107,8 @@ oli_box_cv:
   title_fr: Curriculum vitae
   show_title: false
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 3
 
 oli_box_edu:
@@ -121,8 +121,8 @@ oli_box_edu:
   title_fr: Education
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 4
 
 oli_box_mission:
@@ -134,8 +134,8 @@ oli_box_mission:
   title_fr: Mission
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 5
 
 oli_box_pubs:
@@ -147,8 +147,8 @@ oli_box_pubs:
   title_fr: Publications Representatives
   show_title: true
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 6
 
 # ---------------------------------------------------------------------- Natalie
@@ -161,8 +161,8 @@ nat_box_expertise:
   title_fr: Expertise
   show_title: true
   locked: true
-  visible: false
   audience: 0
+  visibility: 1
   position: 1
 
 # Disponibilité only visible from intranet
@@ -173,8 +173,8 @@ nat_box_availability:
   title_fr: Disponibilité
   show_title: true
   locked: false
-  visible: true
   audience: 2
+  visibility: 0
   position: 2
 
 nat_box_work:
@@ -184,7 +184,7 @@ nat_box_work:
   title_fr: Travail en Cours
   show_title: true
   locked: false
-  visible: true
+  visibility: 0
   audience: 1
   position: 3
 
@@ -197,8 +197,8 @@ nat_box_mission:
   title_fr: Mission
   show_title: true
   locked: true
-  visible: false
   audience: 0
+  visibility: 2
   position: 4
 
 nat_box_bio:
@@ -210,8 +210,8 @@ nat_box_bio:
   title_fr: Biographie
   show_title: false
   locked: true
-  visible: false
   audience: 0
+  visibility: 1
   position: 5
 
 nat_box_cv:
@@ -223,8 +223,8 @@ nat_box_cv:
   title_fr: Curriculum vitae
   show_title: false
   locked: true
-  visible: true
   audience: 0
+  visibility: 0
   position: 6
 
 nat_box_edu_en:
@@ -237,8 +237,8 @@ nat_box_edu_en:
   title_fr: Education
   show_title: true
   locked: true
-  visible: false
   audience: 0
+  visibility: 0
   position: 7
 
 nat_box_missions:
@@ -250,6 +250,6 @@ nat_box_missions:
   title_fr: Mission
   show_title: true
   locked: true
-  visible: false
   audience: 0
+  visibility: 0
   position: 8

--- a/test/fixtures/educations.yml
+++ b/test/fixtures/educations.yml
@@ -8,8 +8,8 @@ gio_edu_uni:
   school:   "Università di Trieste"
   year_begin: 1990
   year_end:  1997
-  visible: true
   audience: 0
+  visibility: 0
   position: 1
 
 gio_edu_phd:
@@ -22,7 +22,7 @@ gio_edu_phd:
   school:   "EPFL"
   year_begin: 2002
   year_end:  2024
-  visible: true
   audience: 0
+  visibility: 0
   position: 2
 

--- a/test/fixtures/experiences.yml
+++ b/test/fixtures/experiences.yml
@@ -5,8 +5,8 @@ giova_exp_algo:
   location: "EPFL – Lausanne"
   year_begin: 2002
   year_end: 2015
-  visible: true
   audience: 0
+  visibility: 0
   position: 1
 
 giova_exp_kandou:
@@ -16,8 +16,8 @@ giova_exp_kandou:
   location: "Kandou"
   year_begin: 2011
   year_end: 2017
-  visible: true
   audience: 0
+  visibility: 0
   position: 2
 
 giova_exp_vpsi:
@@ -26,6 +26,6 @@ giova_exp_vpsi:
   title_fr: "DevOps / FullStack dev"
   location: "EPFL"
   year_begin: 2017
-  visible: true
   audience: 0
+  visibility: 0
   position: 3

--- a/test/fixtures/publications.yml
+++ b/test/fixtures/publications.yml
@@ -6,6 +6,6 @@ gio_publication0:
   year: 2003
   journal: "American Physical Society"
   profile: giova
-  visible: true
   audience: 0
+  visibility: 0
   position: 1

--- a/test/fixtures/socials.yml
+++ b/test/fixtures/socials.yml
@@ -4,21 +4,21 @@ gio_social_linkedin:
   tag: linkedin
   sciper: 121769
   value: giovannicangiani
-  visible: true
   audience: 0
+  visibility: 0
 
 gio_social_github:
   profile: giova
   tag: github
   sciper: 123456
   value: multiscan
-  visible: false
   audience: 0
+  visibility: 1
 
 domq_social_linkedin:
   profile: domq
   tag: linkedin
   sciper: 123456
   value: domq
-  visible: true
   audience: 0
+  visibility: 0


### PR DESCRIPTION
This splits the integrated audience+visibility into two separate responsibilities: audience (world, intranet, authenticated user) and visibility (published, draft, hidden).
Reseed needed because we change the migrations... we can still do this while it is not yet in prod.
Fixes #9 