### PR TITLE
Added expertise field to profiles table and fixed test data

### DIFF
--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 module ProfilesHelper
-  def profile_text_field(form, attr, placeholder)
-    lb = form.label form.object.class.send(:human_attribute_name, attr), class: "col-sm-3  col-form-label"
-    fd = tag.div(class: "col-sm-9") do
-      form.text_field attr, class: "form-control", placeholder: placeholder
-    end
-    lb + fd
-  end
-
   def single_text_field(form, field, extracls = "")
     a = field.to_sym
     oc = form.object.class
@@ -21,13 +13,6 @@ module ProfilesHelper
     content = translations.map do |l|
       single_text_field(form, "#{field}_#{l}", "tr_target_#{l}")
     end
-    # oc = form.object.class
-    # content = translations.map do |l|
-    #   a = "#{field}_#{l}".to_sym
-    #   tag.div(class: "form-group") do
-    #     form.label(oc.send(:human_attribute_name, a)) + form.text_field(a, placeholder: true)
-    #   end
-    # end
     safe_join(content)
   end
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -21,7 +21,6 @@
 			<%= show_attribute_switch(form, :show_photo) %>
 		</div>
 	</div>
-
 	<% if @person.default_phone.present? %>
 	<div class="form-group row">
 		<%= form.label t('person.phone'), class: "col-sm-3  col-form-label" %>
@@ -33,7 +32,10 @@
 		</div>
 	</div>
 	<% end %>
-
+	<div class="form-group row">
+		<%= profile_text_field(form, :expertise_fr, "Escrime") %>
+		<%= profile_text_field(form, :expertise_en, "Spider sense") %>
+	</div>
 	<div class="form-group row">
 		<%= profile_text_field(form, :nationality_fr, "suisse, français") %>
 		<%= profile_text_field(form, :nationality_en, "suiss, french") %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,5 +1,4 @@
 <%= turbo_frame_tag "profile_form" do %>
-
 <% if profile.errors.any? %>
   <div style="color: red">
     <h2><%= t("error.profile", count: profile.errors.count) %></h2>
@@ -10,11 +9,10 @@
     </ul>
   </div>
 <% end %>
+<% translations = profile.translations %>
 
 
-<%= form_with(model: profile, local: false) do |form| %>
-
-
+<%= form_with(model: profile, local: false, class: "instaform") do |form| %>
 	<div class="form-group row">
 		<%= form.label t('person.photo'), class: "col-sm-3  col-form-label" %>
 		<div class="col-sm-9 inform">
@@ -32,24 +30,16 @@
 		</div>
 	</div>
 	<% end %>
-	<div class="form-group row">
-		<%= profile_text_field(form, :expertise_fr, "Escrime") %>
-		<%= profile_text_field(form, :expertise_en, "Spider sense") %>
-	</div>
-	<div class="form-group row">
-		<%= profile_text_field(form, :nationality_fr, "suisse, français") %>
-		<%= profile_text_field(form, :nationality_en, "suiss, french") %>
-		<div class="col-sm-9 offset-sm-3">
-			<%= show_attribute_switch(form, :show_nationality) %>
-		</div>
-	</div>
 
+  <%= translated_text_fields(form, :expertise, translations) %>
+  <%= translated_text_fields(form, :nationality, translations) %>
+	<div class="col-sm-9 offset-sm-3">
+		<%= show_attribute_switch(form, :show_nationality) %>
+	</div>
 	<hr>
-	<div class="form-group row">
-		<%= profile_text_field(form, :personal_web_url, "https://www.epfl.ch/labs/MYLAB/") %>
-		<div class="col-sm-9 offset-sm-3">
-			<%= show_attribute_switch(form, :show_weburl) %>
-		</div>
+	<%= single_text_field(form, :personal_web_url) %>
+	<div class="col-sm-9 offset-sm-3">
+		<%= show_attribute_switch(form, :show_weburl) %>
 	</div>
 
 	<hr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,6 +264,15 @@ en:
         field_de: "Festkörperphysik"
         director: "John Doe"
         school: "Princeton University"
+      profile:
+        expertise_fr: "Escrime"
+        expertise_en: "Spider sense"
+        expertise_it: "Fisica dei solidi"
+        expertise_de: "Spider sense"
+        nationality_en: "swiss, french"
+        nationality_fr: "suisse, français"
+        nationality_de: "schweizer, französisch"
+        personal_web_url: "https://slideshot.epfl.ch/"
   activerecord:
     models:
       award: "award"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -216,6 +216,28 @@ fr:
     visible: "visible"
     visible_address: "address"
   work_experience: "Parcours professionnel"
+  helpers:
+    placeholder:
+      education:
+        title_en: "PhD."
+        title_fr: "Doctorat"
+        title_it: "Dottorato"
+        title_de: "Doktortitel"
+        field_en: "Solid state physics"
+        field_fr: "Physique du solide"
+        field_it: "Fisica dello stato solido"
+        field_de: "Festkörperphysik"
+        director: "John Doe"
+        school: "Princeton University"
+      profile:
+        expertise_fr: "Escrime"
+        expertise_en: "Spider sense"
+        expertise_it: "Fisica dei solidi"
+        expertise_de: "Spider sense"
+        nationality_en: "swiss, french"
+        nationality_fr: "suisse, français"
+        nationality_de: "schweizer, französisch"
+        personal_web_url: "https://slideshot.epfl.ch/"
   activerecord:
     models:
       award: "award"

--- a/db/migrate/20230606141719_create_profiles.rb
+++ b/db/migrate/20230606141719_create_profiles.rb
@@ -18,6 +18,11 @@ class CreateProfiles < ActiveRecord::Migration[7.0]
       t.string :phone, default: nil
 
       # Translatable attributes
+      t.text :expertise_en
+      t.text :expertise_fr
+      t.text :expertise_it
+      t.text :expertise_de
+
       t.string :nationality_en
       t.string :nationality_fr
       t.string :nationality_it

--- a/db/people_schema.rb
+++ b/db/people_schema.rb
@@ -248,6 +248,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_22_073648) do
     t.boolean "show_weburl", default: false
     t.string "personal_web_url"
     t.string "phone"
+    t.text "expertise_en"
+    t.text "expertise_fr"
+    t.text "expertise_it"
+    t.text "expertise_de"
     t.string "nationality_en"
     t.string "nationality_fr"
     t.string "nationality_it"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -152,6 +152,10 @@ namespace :legacy do
       profile.personal_web_url = url if url.present?
       profile.show_weburl = cv.web_perso_show == "1"
 
+      cv_en.expertise.present? || cv_fr.expertise.present?
+      profile.expertise_fr = cv_fr.sanitized_expertise if cv_fr.expertise.present?
+      profile.expertise_en = cv_en.sanitized_expertise if cv_en.expertise.present?
+
       unless profile.save
         errs = profile.errors.map { |err| "#{err.attribute}: #{err.type}" }.join(", ")
         puts "ERROR creating profile: #{errs}"
@@ -200,21 +204,6 @@ namespace :legacy do
             errs = b.errors.map { |err| "#{err.attribute}: #{err.type}" }.join(", ")
             puts "Skipping invalid box #{ob.id} (sciper: #{profile.sciper}): #{errs}"
           end
-        end
-      end
-
-      # ---------------------------------------------------------- Special Boxes
-
-      # Expertise is the only rich text  box whose content is in the cv table
-      if cv_en.expertise.present? || cv_fr.expertise.present?
-        m = mboxes['expertise']
-        b = RichTextBox.from_model(m)
-        b.profile = profile
-        b.content_fr = cv_fr.sanitized_expertise if cv_fr.expertise.present?
-        b.content_en = cv_en.sanitized_expertise if cv_en.expertise.present?
-        unless b.save
-          errs = b.errors.map { |err| "#{err.attribute}: #{err.type}" }.join(", ")
-          puts "Skipping invalid expertise (sciper: #{profile.sciper}): #{errs}"
         end
       end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -152,7 +152,6 @@ namespace :legacy do
       profile.personal_web_url = url if url.present?
       profile.show_weburl = cv.web_perso_show == "1"
 
-      cv_en.expertise.present? || cv_fr.expertise.present?
       profile.expertise_fr = cv_fr.sanitized_expertise if cv_fr.expertise.present?
       profile.expertise_en = cv_en.sanitized_expertise if cv_en.expertise.present?
 

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -12,7 +12,7 @@ gio_box_expertise_fr:
   body: >
     HPC, Algorithmes, Réseaux, Programmation, IT, DBA, Unix, Physique des solides computationnelle
 
-giova_exp_text_algo: 
+giova_exp_text_algo_en: 
   record: giova_exp_algo (Experience) 
   name: description_en
   body: >
@@ -25,7 +25,7 @@ giova_exp_text_algo:
     system and HPC cluster. I also work as a scientific advisor and developer in a
     web2.0 project.
 
-giova_exp_text_algo: 
+giova_exp_text_algo_fr: 
   record: giova_exp_algo (Experience) 
   name: description_fr
   body: >
@@ -39,7 +39,7 @@ giova_exp_text_algo:
     projet web2.0.
 
 
-giova_exp_text_kandou: 
+giova_exp_text_kandou_en: 
   record: giova_exp_kandou (Experience) 
   name: description_en
   body: >
@@ -48,9 +48,9 @@ giova_exp_text_kandou:
     HPC, web developer.
 
 
-giova_exp_text_kandou: 
+giova_exp_text_kandou_fr: 
   record: giova_exp_kandou (Experience) 
-  name: description_en
+  name: description_fr
   body: >
     Responsable de tout ce qui concerne les technologies de l'information 
     pour l'entreprise : acquisition de matériel, déploiement, installation 
@@ -59,17 +59,6 @@ giova_exp_text_kandou:
     pour le web.
 
 # ---------------------------------------------------------------------- Olivier
-oli_box_expertise_en:
-  record: oli_box_expertise (Box)
-  name: content_en
-  body: >
-    Information theory<br/>Random matrices<br/>Stochastic calculus
-
-oli_box_expertise_fr:
-  record: oli_box_expertise (Box)
-  name: content_fr
-  body: >
-    Théorie de l'information&nbsp;<br/>Matrices aléatoires<br/>Calcul stochastique
 
 oli_box_cv_en:
   record: oli_box_cv (Box)
@@ -202,15 +191,6 @@ nat_box_mission_en:
     Dépositaire de la Charte graphique de l'EPFL, elle s'occupe de la mise au point des maquettes, du respect de l'orthodoxie de l'aspect et de la validité des différentes pages, ainsi que du choix des images illustrant les sites.
     Elle est également responsable du suivi de l'actualité et de la mise à jour sur les portails institutionnels.
     Sites de référence: <a href="http://atelierweb.epfl.ch">atelier web:</a> création de site web à l'epfl  et <a href="http://kis.epfl.ch">KIS</a>.
-
-nat_box_expertise_fr:
-  record: nat_box_expertise (Box)
-  name: content_fr
-  body: >
-    architecture web - ergonomie - usability - ergonomie - design et 
-    architecture de l&apos;information - cms - iconographie - 
-    graphisme web - charte graphique - design - logo - expertise communication 
-    web - html - css2 - ui design
 
 nat_box_cv_fr:
   record: nat_box_cv (Box)

--- a/test/fixtures/boxes.yml
+++ b/test/fixtures/boxes.yml
@@ -1,22 +1,7 @@
 # --------------------------------------------------------------------------- Me
-gio_box_expertise:
-  type: "RichTextBox"
-  model: mbox_expertise
-  profile: giova
-  section: bio
-  model: mbox_expertise
-  title_en: Expertise
-  title_fr: Domaines de compétences
-  locked_title: true
-  show_title: true
-  audience: 0
-  visibility: 0
-  position: 1
-
 gio_box_education:
   type: "IndexBox"
   subkind: "Education"
-  model: mbox_education
   profile: giova
   section: bio
   model: mbox_education
@@ -72,19 +57,6 @@ edo_box_awards:
   position: 4
 
 # ---------------------------------------------------------------------- Olivier
-oli_box_expertise:
-  type: "RichTextBox"
-  model: mbox_expertise
-  profile: olivier
-  section: bio
-  title_en: Expertise
-  title_fr: Expertise
-  locked_title: true
-  show_title: true
-  audience: 0
-  visibility: 0
-  position: 1
-
 oli_box_bio:
   type: "RichTextBox"
   model: mbox_biography

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -18,8 +18,8 @@ edouard:
   nationality_fr: Suisse
   nationality_en: Swiss
   personal_web_url: "http://dcsl.epfl.ch"
-  # expertise_fr: "Computer Systems, Data center networks, Virtualization"
-  # expertise_en: "Computer Systems, Data center infrastructure and networking, Operating systems, Virtualization"
+  expertise_fr: "Computer Systems, Data center networks, Virtualization"
+  expertise_en: "Computer Systems, Data center infrastructure and networking, Operating systems, Virtualization"
 
 francesco:
   sciper: "363674"
@@ -74,7 +74,7 @@ natalie:
   personal_web_url: "https://go.epfl.ch/web-EPFL"
   # curriculum_fr: "Séminaire «User Experience» 2006 par Nielsen Norman Group, San Francisco, USA<br><b>2005</b> Séminaire d'une journée: «Optimiser sa présence sur le Web pour acquérir et fidéliser»<br><b>2004</b> Séminaire «User Experience 2004» par Nielsen Norman Group, USA à Amsterdam, <br><b>2002</b> Séminaire «Usability Week 2002» par Nielsen Norman Group, NY, USA <br> <b>2001</b> Certificat de spécialisation postgrade en Visualisation et communication informatique, EPFL <br><b>1995</b> Diplôme d'architecte EPFL"
   # mission_fr: "Architecte de formation, s'est spécialisée dans le graphisme, la création et l'ergonomie des sites web. Dépositaire de la Charte graphique de l'EPFL, elle s'occupe de la mise au point des maquettes, du respect de l'orthodoxie, de l'aspect et de la validité des différentes pages, ainsi que du choix des images illustrant les sites. Elle dispense aussi des conseils sur la manière de concevoir et de mettre en oeuvre un site web, ainsi que sur le choix des applications et des outils mis à disposition par le KIS. Elle propose une analyse stratégique pour la conduite de projets Internet, et intervient comme expert web dans les groupes de réflexion sur la politique de communication des différentes unités de l'Ecole (VPAA, BSS-IC, SAC, bibliothèque...) Elle est également responsable du suivi de l'actualité et de la mise à jour des portails institutionnels. Depuis le printemps 2004, elle est en charge du projet PolyNex, qui s'intéresse aux équipements multimedia sur le campus. Pendant ses loisirs, elle gère les sites du fameux groupe folk-rock, les <a href=\"http://www.paradajz.com\">Paradajz Vampiri</a>, de sa prof préférée de <a href='http://www.pilates-fitforlife.com/'>Pilates, Miranda Mattig</a>, et de l'<a href='http://a3.epfl.ch/''>Association des Diplômés de l'EPFL</a>, l'A3, où elle est responsable de la COSI (liaison entre l'association et le campus EPFL). Vous pouvez suivre ses aventures exotiques sur le blog <a href='http://nmeystre.hautetfort.com/'>http://nmeystre.hautetfort.com/</a>. Sites de référence: <a href='http://atelierweb.epfl.ch'>atelier web:</a> création de site web à l'epfl  et <a href='http://kis.epfl.ch'>KIS</a>."
-  # expertise_fr: "Architecture web - ergonomie - usability - ergonomie - design et architecture de l&apos;information - cms - iconographie - graphisme web - charte graphique - design - logo - expertise communication web - html - css2 - ui design"
+  expertise_fr: "Architecture web - ergonomie - usability - ergonomie - design et architecture de l&apos;information - cms - iconographie - graphisme web - charte graphique - design - logo - expertise communication web - html - css2 - ui design"
 
 olivier:
   sciper: "107931"


### PR DESCRIPTION
- Added `expertise` field in multiple languages (`expertise_en`, `expertise_fr`, `expertise_it`, `expertise_de`) to the `profiles` table
- Updated `CreateProfiles` migration to use `t.text` instead of `t.string` to prevent data length errors (to be discussed)
- Fixed and removed outdated or incorrect test data
- Updated the form to include the `expertise` field using temporary `profile_text_field`