### PR TITLE
[refac] Globalization & Translations Refactor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,9 +41,9 @@ class ApplicationController < ActionController::Base
 
   def switch_locale(&action)
     locale = params[:lang] || I18n.default_locale
-    Thread.current[:primary_lang] = locale
-    Thread.current[:fallback_lang] = I18n.default_locale
-    Thread.current[:gender] = nil
+    Current.primary_lang = locale
+    Current.fallback_lang = I18n.default_locale
+    Current.gender = nil
     I18n.with_locale(locale, &action)
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -40,7 +40,7 @@ class PeopleController < ApplicationController
     compute_audience(@sciper)
     @admin_data = @audience > 1 ? @person.admin_data : nil
 
-    Thread.current[:gender] = @person.gender
+    Current.gender = @person.gender
 
     # TODO: would a sort of "PublicSection" class make things easier here ?
     #       keep in mind that here we only manage boxes but we will have
@@ -49,7 +49,7 @@ class PeopleController < ApplicationController
     return unless @profile
 
     # take into account profile's enaled languages
-    Thread.current[:translations] = @profile.translations
+    Current.translations = @profile.translations
 
     # teachers are supposed to all have a profile
     @ta = Isa::Teaching.new(@sciper) if @person.possibly_teacher?

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -58,16 +58,14 @@ module Translatable
   # return translation of a translated attribute in the required locale
   # if available otherwise return the translation in the default locale
   def translation_for(attribute, primary_lang = nil, fallback_lang = nil)
-    # primary_lang ||= Thread.current[:primary_lang] || I18n.locale
-    # fallback_lang ||= Thread.current[:fallback_lang] || I18n.default_locale
-    primary_lang ||= I18n.locale
-    fallback_lang ||= Thread.current[:translations] || %w[en fr it de]
+    primary_lang ||= Current.primary_lang || I18n.locale
+    fallback_lang ||= Current.translations || %w[en fr it de]
     langs = [primary_lang] + fallback_lang
 
     if respond_to?("#{attribute}_en")
-      langs.map { |l| send "#{attribute}_#{l}" }.compact.first
+      langs.map { |l| send("#{attribute}_#{l}") }.compact.first
     else
-      langs.map { |l| instance_variable_get "@#{attribute}_#{l}" }.compact.first
+      langs.map { |l| instance_variable_get("@#{attribute}_#{l}") }.compact.first
     end
   end
 
@@ -84,8 +82,8 @@ module Translatable
   end
 
   def translated_body_for(attribute, primary_lang = nil, fallback_lang = nil)
-    primary_lang ||= Thread.current[:primary_lang] || I18n.locale
-    fallback_lang ||= Thread.current[:fallback_lang] || I18n.default_locale
+    primary_lang ||= Current.primary_lang || I18n.locale
+    fallback_lang ||= Current.fallback_lang || I18n.default_locale
 
     t = send("#{attribute}_#{primary_lang}")
     t = send("#{attribute}_#{fallback_lang}") if primary_lang != fallback_lang && (t.id.nil? || t.body.empty?)
@@ -93,13 +91,13 @@ module Translatable
   end
 
   def inclusive_translation_for(attribute, gender = nil, primary_lang = nil, fallback_lang = nil)
-    gender ||= Thread.current[:gender]
+    gender ||= Current.gender
     if gender.nil?
       raise "inclusive_translation_for requires gender to be passed explicitly or set as Thread.current[:gender]"
     end
 
-    primary_lang ||= Thread.current[:primary_lang] || I18n.locale
-    fallback_lang ||= Thread.current[:fallback_lang] || I18n.default_locale
+    primary_lang ||= Current.primary_lang || I18n.locale
+    fallback_lang ||= Current.fallback_lang || I18n.default_locale
     inclusive_translation_for!(attribute, gender,
                                primary_lang) || inclusive_translation_for!(attribute, gender, fallback_lang)
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Current < ActiveSupport::CurrentAttributes
-  attribute :session
+  attribute :session, :primary_lang, :fallback_lang, :gender, :translations
   delegate :user, to: :session, allow_nil: true
 end


### PR DESCRIPTION
- Replace usage of Thread.current with ActiveSupport::CurrentAttributes (Current) for managing locale, fallback language, gender, and translations.
- Update ApplicationController’s switch_locale to set Current.primary_lang and Current.fallback_lang.
- Modify the Translatable module methods to use Current attributes instead of Thread.current.