### PR TITLE
Refactor `common_editor` and improve UI spacing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -121,31 +121,6 @@ module ApplicationHelper
     end
   end
 
-  def common_editor(title: nil, &block)
-    dismiss_button = tag.button("✕",
-                                type: "button",
-                                class: "btn btn-link text-danger fs-4 p-0 ms-2 float-end",
-                                data: { action: "click->dismissable#dismiss" },
-                                aria: { label: I18n.t("action.cancel") })
-
-    c = []
-    c << tag.div(class: "d-flex align-items-center justify-content-between mb-2") do
-      safe_join([tag.h3(title), dismiss_button])
-    end
-
-    c << tag.div(capture(&block))
-
-    c1 = tag.div(class: "container") do
-      safe_join(c)
-    end
-
-    safe_join [
-      turbo_stream.update("editor") { tag.div(c1, id: "editor_content") },
-      turbo_stream.replace("flash-messages", partial: "shared/flash")
-    ]
-  end
-
-
   # https://medium.com/@fabriciobonjorno/toast-with-stimulus-and-customized-error-messages-easily-and-quickly-0ff5e455ec80
   def errors_for(form, field)
     tag.p(form.object.errors[field].try(:first), class: 'text-danger ms-2 fw-medium')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -121,6 +121,31 @@ module ApplicationHelper
     end
   end
 
+  def common_editor(title: nil, &block)
+    dismiss_button = tag.button("✕",
+                                type: "button",
+                                class: "btn btn-link text-danger fs-4 p-0 ms-2 float-end",
+                                data: { action: "click->dismissable#dismiss" },
+                                aria: { label: I18n.t("action.cancel") })
+
+    c = []
+    c << tag.div(class: "d-flex align-items-center justify-content-between mb-2") do
+      safe_join([tag.h3(title), dismiss_button])
+    end
+
+    c << tag.div(capture(&block))
+
+    c1 = tag.div(class: "container") do
+      safe_join(c)
+    end
+
+    safe_join [
+      turbo_stream.update("editor") { tag.div(c1, id: "editor_content") },
+      turbo_stream.replace("flash-messages", partial: "shared/flash")
+    ]
+  end
+
+
   # https://medium.com/@fabriciobonjorno/toast-with-stimulus-and-customized-error-messages-easily-and-quickly-0ff5e455ec80
   def errors_for(form, field)
     tag.p(form.object.errors[field].try(:first), class: 'text-danger ms-2 fw-medium')

--- a/app/helpers/backoffice_helper.rb
+++ b/app/helpers/backoffice_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-module ProfilesHelper
-  def form_group(help: nil, **opts, &block)
+module BackofficeHelper
+
+  def form_group(help: nil, extracls: "", &block)
     c = []
     c << tag.div(class: "form-group #{opts[:extracls]}") do
       capture(&block)
@@ -257,6 +258,34 @@ module ProfilesHelper
     # this is if we want to have the current locale or the first of the list
     t = current_work_translation(item)
     "tr_enable_#{t}"
+  end
+
+  def common_editor(title: nil, &block)
+    c1 = []
+    # TODO: not nice to have an empty h3 but without it the close button will no
+    #       longer stay on the right. No time to fight with CSS and fix this now
+    c1 << tag.h3(title) # if title.present?
+    c1 << tag.button(
+      "✕",
+      type: "button",
+      class: "btn btn-link text-danger fs-4 p-0 ms-2 float-end",
+      data: { action: "click->dismissable#dismiss" },
+      aria: { label: I18n.t("action.cancel") }
+    )
+
+    c = []
+    c << tag.div(class: "d-flex align-items-center justify-content-between mb-2") do
+      safe_join(c1)
+    end
+    c << tag.div(capture(&block))
+    c = tag.div(class: "container") do
+      safe_join(c)
+    end
+
+    safe_join [
+      turbo_stream.update("editor") { tag.div(c, id: "editor_content") },
+      turbo_stream.replace("flash-messages", partial: "shared/flash")
+    ]
   end
 
   def dismiss_common_editor

--- a/app/helpers/backoffice_helper.rb
+++ b/app/helpers/backoffice_helper.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module BackofficeHelper
-
-  def form_group(help: nil, extracls: "", &block)
+  def form_group(help: nil, **opts, &block)
     c = []
     c << tag.div(class: "form-group #{opts[:extracls]}") do
       capture(&block)

--- a/app/helpers/boxes_helper.rb
+++ b/app/helpers/boxes_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module BoxesHelper
-end

--- a/app/helpers/experiences_helper.rb
+++ b/app/helpers/experiences_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module ExperiencesHelper
-end

--- a/app/helpers/names_helper.rb
+++ b/app/helpers/names_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module NamesHelper
-end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -259,19 +259,6 @@ module ProfilesHelper
     "tr_enable_#{t}"
   end
 
-  def common_editor(title: nil, &block)
-    c = []
-    c << tag.h3(title) if title.present?
-    c << tag.div(capture(&block))
-    c1 = tag.div(class: "container") do
-      safe_join(c)
-    end
-    safe_join [
-      turbo_stream.update("editor") { tag.div(c1, id: "editor_content") },
-      turbo_stream.replace("flash-messages", partial: "shared/flash")
-    ]
-  end
-
   def dismiss_common_editor
     safe_join [
       turbo_stream.update("editor") { "" },

--- a/app/views/achievements/edit.turbo_stream.erb
+++ b/app/views/achievements/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "achievements/form", profile: nil, achievement: @achievement
 } %>

--- a/app/views/achievements/new.turbo_stream.erb
+++ b/app/views/achievements/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "achievements/form", profile: @profile, achievement: @achievement
 } %>

--- a/app/views/awards/edit.turbo_stream.erb
+++ b/app/views/awards/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "awards/form", profile: nil, award: @award
 } %>

--- a/app/views/awards/new.turbo_stream.erb
+++ b/app/views/awards/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "awards/form", profile: @profile, award: @award
 } %>

--- a/app/views/educations/_editable_education.html.erb
+++ b/app/views/educations/_editable_education.html.erb
@@ -9,7 +9,7 @@
         <p class="text-muted small mb-0">
           <%= period_text(education.year_begin, education.year_end) %> <%= education.school %>
           <br>
-          <%= t("education.directedby")%> <%= education.director.presence || t("general.not_available") %>
+          <%= t("educations.directedby")%> <%= education.director.presence || t("general.not_available") %>
         </p>
       </div>
       <div class="col-md-4 text-right">

--- a/app/views/educations/_education.html.erb
+++ b/app/views/educations/_education.html.erb
@@ -2,8 +2,8 @@
   <div class="col-md-8">
     <div class="d-md-flex">
       <h4 class="h5 mb-0 mr-1"><%= education.t_title %></h4>
-      <span class="d-none d-md-block ml-1 mr-1 font-weight-bold">|</span> 
-      <span> <%= education.t_field %></span> 
+      <span class="d-none d-md-block ml-1 mr-1 font-weight-bold">|</span>
+      <span> <%= education.t_field %></span>
     </div>
 
     <p class="text-muted small mb-0">
@@ -11,7 +11,7 @@
       <%= education.school %>
       <% if education.director.present? %>
         <br>
-        <%= t("education.directedby")%>
+        <%= t("educations.directedby")%>
         <%= education.director %>
       <% end %>
     </p>

--- a/app/views/educations/edit.turbo_stream.erb
+++ b/app/views/educations/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "educations/form", profile: nil, education: @education
 } %>

--- a/app/views/educations/new.turbo_stream.erb
+++ b/app/views/educations/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "educations/form", profile: @profile, education: @education
 } %>

--- a/app/views/experiences/edit.turbo_stream.erb
+++ b/app/views/experiences/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "experiences/form", profile: nil, experience: @experience
 } %>

--- a/app/views/experiences/new.turbo_stream.erb
+++ b/app/views/experiences/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "experiences/form", profile: @profile, experience: @experience
 } %>

--- a/app/views/function_changes/new.turbo_stream.erb
+++ b/app/views/function_changes/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "function_changes/form"
 } %>

--- a/app/views/infosciences/edit.turbo_stream.erb
+++ b/app/views/infosciences/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "infosciences/form", profile: nil, infoscience: @infoscience
 } %>

--- a/app/views/infosciences/new.turbo_stream.erb
+++ b/app/views/infosciences/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "infosciences/form", profile: @profile, infoscience: @infoscience
 } %>

--- a/app/views/profiles/name_change/edit.turbo_stream.erb
+++ b/app/views/profiles/name_change/edit.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= common_editor do %>
-<ul class="nav nav-tabs mt-5" role="tablist">
+<ul class="nav nav-tabs mt-1" role="tablist">
   <% ["official", "usual"].each do |type| %>
     <%
       id = "name_change_#{type}"

--- a/app/views/publications/edit.turbo_stream.erb
+++ b/app/views/publications/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "publications/form", profile: nil, publication: @publication
 } %>

--- a/app/views/publications/new.turbo_stream.erb
+++ b/app/views/publications/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "publications/form", profile: @profile, publication: @publication
 } %>

--- a/app/views/socials/edit.turbo_stream.erb
+++ b/app/views/socials/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "socials/form", profile: nil, social: @social
 } %>

--- a/app/views/socials/new.turbo_stream.erb
+++ b/app/views/socials/new.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= common_editor {
+<%= common_editor(title: t(".form_title")) {
   render "socials/form", profile: @profile, social: @social
 } %>

--- a/config/locales/achievements/de.yml
+++ b/config/locales/achievements/de.yml
@@ -11,6 +11,10 @@ de:
     placeholder:
       achievement: {}
   achievements:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       category: ''
       description: ''

--- a/config/locales/achievements/en.yml
+++ b/config/locales/achievements/en.yml
@@ -24,6 +24,10 @@ en:
           wurde in Economis, Forbes und anderen Medien vorgestellt
         url: https://doi.org/10.1021/acs.est.2c05777
   achievements:
+    edit:
+      form_title: "Editing Achievement"
+    new:
+      form_title: "Creating a new Achievement"
     form:
       category: Category
       description: Description

--- a/config/locales/achievements/fr.yml
+++ b/config/locales/achievements/fr.yml
@@ -11,6 +11,10 @@ fr:
     placeholder:
       achievement: {}
   achievements:
+    edit:
+      form_title: "Editing Achievement"
+    new:
+      form_title: "Creating a new Achievement"
     form:
       category: Catégorie
       description: Description

--- a/config/locales/achievements/it.yml
+++ b/config/locales/achievements/it.yml
@@ -11,6 +11,10 @@ it:
     placeholder:
       achievement: {}
   achievements:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       category: ''
       description: ''

--- a/config/locales/awards/de.yml
+++ b/config/locales/awards/de.yml
@@ -21,5 +21,9 @@ de:
         url: url
         year: Jahr
   awards:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       help: {}

--- a/config/locales/awards/en.yml
+++ b/config/locales/awards/en.yml
@@ -27,6 +27,10 @@ en:
         url: url
         year: Year
   awards:
+    edit:
+      form_title: "Editing Award"
+    new:
+      form_title: "Creating a new Award"
     form:
       help:
         category: Dropdown menu for award category

--- a/config/locales/awards/fr.yml
+++ b/config/locales/awards/fr.yml
@@ -21,5 +21,9 @@ fr:
         url: url
         year: Année
   awards:
+    edit:
+      form_title: "Editing Award"
+    new:
+      form_title: "Creating a new Award"
     form:
       help: {}

--- a/config/locales/awards/it.yml
+++ b/config/locales/awards/it.yml
@@ -21,5 +21,9 @@ it:
         url: url
         year: Year
   awards:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       help: {}

--- a/config/locales/educations/de.yml
+++ b/config/locales/educations/de.yml
@@ -26,6 +26,7 @@ de:
         year_begin: from year
         year_end: to year
   educations:
+    directedby: "Directed by"
     edit:
       form_title: ''
     new:

--- a/config/locales/educations/de.yml
+++ b/config/locales/educations/de.yml
@@ -26,5 +26,9 @@ de:
         year_begin: from year
         year_end: to year
   educations:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       period: period (years)

--- a/config/locales/educations/en.yml
+++ b/config/locales/educations/en.yml
@@ -36,5 +36,9 @@ en:
         year_begin: from year
         year_end: to year
   educations:
+    edit:
+      form_title: "Editing Education"
+    new:
+      form_title: "Creating a new Education"
     form:
       period: period (years)

--- a/config/locales/educations/en.yml
+++ b/config/locales/educations/en.yml
@@ -36,6 +36,7 @@ en:
         year_begin: from year
         year_end: to year
   educations:
+    directedby: "Directed by"
     edit:
       form_title: "Editing Education"
     new:

--- a/config/locales/educations/fr.yml
+++ b/config/locales/educations/fr.yml
@@ -27,6 +27,7 @@ fr:
         year_begin: de (année)
         year_end: à (année)
   educations:
+    directedby: "Dirigée par"
     edit:
       form_title: "Editing Education"
     new:

--- a/config/locales/educations/fr.yml
+++ b/config/locales/educations/fr.yml
@@ -27,5 +27,9 @@ fr:
         year_begin: de (année)
         year_end: à (année)
   educations:
+    edit:
+      form_title: "Editing Education"
+    new:
+      form_title: "Creating a new Education"
     form:
       period: période (en années)

--- a/config/locales/educations/it.yml
+++ b/config/locales/educations/it.yml
@@ -26,5 +26,9 @@ it:
         year_begin: from year
         year_end: to year
   educations:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       period: period (years)

--- a/config/locales/educations/it.yml
+++ b/config/locales/educations/it.yml
@@ -26,6 +26,7 @@ it:
         year_begin: from year
         year_end: to year
   educations:
+    directedby: "Con la supervisione di"
     edit:
       form_title: ''
     new:

--- a/config/locales/experiences/de.yml
+++ b/config/locales/experiences/de.yml
@@ -26,5 +26,9 @@ de:
         year_begin: from year
         year_end: to year
   experiences:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       period: Period (years)

--- a/config/locales/experiences/en.yml
+++ b/config/locales/experiences/en.yml
@@ -31,5 +31,9 @@ en:
         year_begin: from year
         year_end: to year
   experiences:
+    edit:
+      form_title: "Editing Work Experience"
+    new:
+      form_title: "Creating a Work Experience"
     form:
       period: Period (years)

--- a/config/locales/experiences/fr.yml
+++ b/config/locales/experiences/fr.yml
@@ -27,5 +27,9 @@ fr:
         year_end: à (année)
 
   experiences:
+    edit:
+      form_title: "Editing Work Experience"
+    new:
+      form_title: "Creating a Work Experience"
     form:
       period: Période (en années)

--- a/config/locales/experiences/it.yml
+++ b/config/locales/experiences/it.yml
@@ -26,5 +26,9 @@ it:
         year_begin: from year
         year_end: to year
   experiences:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       period: Period (years)

--- a/config/locales/infosciences/de.yml
+++ b/config/locales/infosciences/de.yml
@@ -20,5 +20,9 @@ de:
         title: Title
         url: infoscience-exports url
   infosciences:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       create: Save

--- a/config/locales/infosciences/en.yml
+++ b/config/locales/infosciences/en.yml
@@ -21,5 +21,9 @@ en:
         title: Title
         url: infoscience-exports url
   infosciences:
+    edit:
+      form_title: "Editing Infoscience export link"
+    new:
+      form_title: "Creating Infoscience export link"
     form:
       create: Save

--- a/config/locales/infosciences/fr.yml
+++ b/config/locales/infosciences/fr.yml
@@ -21,5 +21,9 @@ fr:
         url: Url issue de infoscience-exports
 
   infosciences:
+    edit:
+      form_title: "Editing Infoscience export link"
+    new:
+      form_title: "Creating Infoscience export link"
     form:
       create: Enregistrer

--- a/config/locales/infosciences/it.yml
+++ b/config/locales/infosciences/it.yml
@@ -20,5 +20,9 @@ it:
         title: Title
         url: infoscience-exports url
   infosciences:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       create: Save

--- a/config/locales/new.yml
+++ b/config/locales/new.yml
@@ -10,6 +10,9 @@ en:
     disabled: "No"
   profile:
     inclusivity: "Show job names in inclusive form (french version)"
+  function_changes:
+    new:
+      form_title: "Function change request"
   profiles:
     hide_gender:
       enabled: "Yes"
@@ -105,6 +108,9 @@ fr:
     disabled: "Non"
   profile:
     inclusivity: "Afficher la forme inclusive des fonctions"
+  function_changes:
+    new:
+      form_title: "Demande de changement de fonction"
   profiles:
     inclusivity: "Inclusivité"
     hide_gender:

--- a/config/locales/publications/de.yml
+++ b/config/locales/publications/de.yml
@@ -32,5 +32,9 @@ de:
         year: Publication year
 
   publications:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     editable_publication:
       link: View the publication

--- a/config/locales/publications/en.yml
+++ b/config/locales/publications/en.yml
@@ -37,5 +37,9 @@ en:
         year: Publication year
 
   publications:
+    edit:
+      form_title: "Editing Publication"
+    new:
+      form_title: "Creating a new Publication"
     editable_publication:
       link: View the publication

--- a/config/locales/publications/fr.yml
+++ b/config/locales/publications/fr.yml
@@ -32,5 +32,9 @@ fr:
         year: Année de publication
 
   publications:
+    edit:
+      form_title: "Editing Publication"
+    new:
+      form_title: "Creating a new Publication"
     editable_publication:
       link: Voir cette publication

--- a/config/locales/publications/it.yml
+++ b/config/locales/publications/it.yml
@@ -32,5 +32,9 @@ it:
         year: Publication year
 
   publications:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     editable_publication:
       link: View the publication

--- a/config/locales/socials/de.yml
+++ b/config/locales/socials/de.yml
@@ -23,6 +23,10 @@ de:
         tag: social type
         value: Identifier
   socials:
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     add:
       add: ''
     form:

--- a/config/locales/socials/en.yml
+++ b/config/locales/socials/en.yml
@@ -26,6 +26,10 @@ en:
   socials:
     add:
       add: Add Social Media Link or Research ID
+    edit:
+      form_title: "Editing Research ID"
+    new:
+      form_title: "Creating a new Research ID"
     form:
       identifier_label:
         facebook: Facebook ID

--- a/config/locales/socials/fr.yml
+++ b/config/locales/socials/fr.yml
@@ -26,6 +26,10 @@ fr:
   socials:
     add:
       add: Ajouter un profil de réseau social ou un identifiant de recherche
+    edit:
+      form_title: "Editing Research ID"
+    new:
+      form_title: "Creating a new Research ID"
     form:
       value: Identifiiant
       identifier_label:

--- a/config/locales/socials/it.yml
+++ b/config/locales/socials/it.yml
@@ -25,6 +25,10 @@ it:
   socials:
     add:
       add: Aggiungi un'altra identità sociale
+    edit:
+      form_title: ''
+    new:
+      form_title: ''
     form:
       identifier_label:
         facebook: ''


### PR DESCRIPTION
**Description:**
This PR refactors the `common_editor` helper to enhance code organization and improve the user interface for editor views.

---

**What’s included:**

* Moved the `common_editor` method to `ApplicationHelper` for global reusability.
* Added a dismiss button (✕) to allow users to exit the common editor view.
* Adjusted the top margin of the tab navigation (`mt-5` → `mt-1`) to improve vertical spacing and reduce visual clutter.

---

**Technical notes:**

* The dismiss button is linked to the Stimulus controller `dismissable#dismiss`.
* The layout uses Bootstrap utility classes for spacing and alignment with a litlle margin tweak.

---

**How to test:**

1. Open a view that uses `common_editor`.
2. Verify the ✕ button appears at the top-right and correctly dismisses the view.
3. Confirm the tabs render with reduced top margin and align well with the header.

