### PR TITLE
[feature] Subtler version

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -28,8 +28,8 @@
 }
 
 #version {
+  color: #a2a2a2;
   font-size: 50%;
-  text-shadow: 0.5px 0.5px 0 #999;
   position: absolute;
   right: 2rem;
   bottom: 0.5rem;

--- a/app/views/layouts/elements/_footer.html.erb
+++ b/app/views/layouts/elements/_footer.html.erb
@@ -92,7 +92,7 @@
 </div>
 <%= tag.div id: 'version' do %>
   <%= link_to t("nav.app_with_version", version: Rails.configuration.version), "https://github.com/epfl-si/people2" %>
-  &#9679;
+  &bull;
   <%= link_to t("nav.issues"), "https://github.com/epfl-si/people2/issues", target: "_blank" %>
 <% end %>
 


### PR DESCRIPTION
Replace `&#9679;` by `&bull;` (● → •) and remove the shadow.