### PR TITLE
[rewrite] Web debugger functionality in development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -98,12 +98,13 @@ SECFILE=${KBPATH}/secrets_prod.sh
 #  - 3 for owner (actually anything > 3)
 FORCE_AUDIENCE=4
 
-# SHOW_ERROR_PAGES, default: unset
-# Development only. If `yes`, Rails will show a nice error page with
-# traceback and console prompt for all errors (including 404s). If
-# `no`, the error pages will behave like production. If unset (the
-# default), only 500s get the traceback and console prompt.
-# SHOW_ERROR_PAGES=yes
+# ERROR_PAGES, default: mix
+# Development only.
+# How the application in dev mode have to treat the errors.
+#   - dev   => show debug error page with traceback and console for all errors
+#   - mix   => show debug error page with traceback and console only for 500
+#   - prod  => show public error pages as in production
+# ERROR_PAGES=dev
 
 # EPFLAPI_BACKEND_URL, default: https://api.epfl.ch/v1
 # The url for the api server. The production instance is much more stable. Switch

--- a/.env.sample
+++ b/.env.sample
@@ -98,12 +98,6 @@ SECFILE=${KBPATH}/secrets_prod.sh
 #  - 3 for owner (actually anything > 3)
 FORCE_AUDIENCE=4
 
-# SHOW_ERROR_PAGES, default: no
-# in development, rails shows a nice error page with traceback and console prompt
-# set this to true if you want to see the actual error page that would be shown
-# in production instead.
-# SHOW_ERROR_PAGES=yes
-
 # EPFLAPI_BACKEND_URL, default: https://api.epfl.ch/v1
 # The url for the api server. The production instance is much more stable. Switch
 # to test only if you need to test new features that are not yet pushed to prod

--- a/.env.sample
+++ b/.env.sample
@@ -98,6 +98,13 @@ SECFILE=${KBPATH}/secrets_prod.sh
 #  - 3 for owner (actually anything > 3)
 FORCE_AUDIENCE=4
 
+# SHOW_ERROR_PAGES, default: unset
+# Development only. If `yes`, Rails will show a nice error page with
+# traceback and console prompt for all errors (including 404s). If
+# `no`, the error pages will behave like production. If unset (the
+# default), only 500s get the traceback and console prompt.
+# SHOW_ERROR_PAGES=yes
+
 # EPFLAPI_BACKEND_URL, default: https://api.epfl.ch/v1
 # The url for the api server. The production instance is much more stable. Switch
 # to test only if you need to test new features that are not yet pushed to prod

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,7 +137,7 @@ class ApplicationController < ActionController::Base
   # depending on `exception`, if Rails.configuration.x.dwim_error_pages
   # is set.
   def rescue_with_handler(exception)
-    return super unless Rails.configuration.x&.dwim_error_pages
+    return super if Rails.configuration.x&.dwim_error_pages.blank?
 
     http_status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception.class.name)
     want_web_debugger = want_web_debugger? exception, http_status

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,12 +134,13 @@ class ApplicationController < ActionController::Base
   end
 
   # Overridden to selectively enable the debugger page in development,
-  # depending on `exception`
+  # depending on `exception`, if Rails.configuration.x.dwim_error_pages
+  # is set.
   def rescue_with_handler(exception)
-    return super unless Rails.env.development?
+    return super unless Rails.configuration.x&.dwim_error_pages
 
     http_status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception.class.name)
-    want_web_debugger = want_web_debugger_in_dev? exception, http_status
+    want_web_debugger = want_web_debugger? exception, http_status
 
     rescue_how = want_web_debugger ? 'with the debugger' : 'with the normal error page'
     logger.error("rescue_with_handler: processing #{exception} exception #{rescue_how}")
@@ -149,7 +150,7 @@ class ApplicationController < ActionController::Base
     super
   end
 
-  def want_web_debugger_in_dev?(_exception, http_status)
+  def want_web_debugger?(_exception, http_status)
     http_status == 500
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,7 +86,7 @@ module People
     # which will probably become config maps
 
     # ENV vars that are read by files in environments/*.rb
-    # development: REDIS_CACHE, SHOW_ERROR_PAGES
+    # development: REDIS_CACHE
     # production: RAILS_LOG_LEVEL
     # db/seed.rb: DEV_SEEDS_PATH, SEEDS_PATH
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,7 +86,7 @@ module People
     # which will probably become config maps
 
     # ENV vars that are read by files in environments/*.rb
-    # development: REDIS_CACHE
+    # development: REDIS_CACHE, SHOW_ERROR_PAGES
     # production: RAILS_LOG_LEVEL
     # db/seed.rb: DEV_SEEDS_PATH, SEEDS_PATH
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,10 @@ module People
     # config.active_storage.variant_processor = :mini_magick
     config.active_storage.variant_processor = :vips
 
+    config.consider_all_requests_local = false
+    # ... but see also ApplicationController#rescue_with_handler in
+    # ../app/controllers/application_controller.rb
+
     # -------------------------------------------------------------
     # Custom generic app configs: everything from ENV with defaults
     # Use as Rails.configuration.KEY

--- a/config/application.rb
+++ b/config/application.rb
@@ -86,7 +86,7 @@ module People
     # which will probably become config maps
 
     # ENV vars that are read by files in environments/*.rb
-    # development: REDIS_CACHE, SHOW_ERROR_PAGES
+    # development: REDIS_CACHE, ERROR_PAGES
     # production: RAILS_LOG_LEVEL
     # db/seed.rb: DEV_SEEDS_PATH, SEEDS_PATH
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,13 +19,16 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  show_error_pages = ENV.fetch('SHOW_ERROR_PAGES', '')
-  if show_error_pages.empty?
-    # Show full error reports only for 500s
-    config.x.dwim_error_pages = true
-  elsif show_error_pages.match?(config.re_true)
+  case ENV.fetch('ERROR_PAGES', 'mix')
+  when 'prod'
+    config.consider_all_requests_local = false
+  when 'dev'
     # Show full error reports (including 404s)
     config.consider_all_requests_local = true
+  else
+    # Show full error reports only for 500s
+    config.consider_all_requests_local = false
+    config.x.dwim_error_pages = true
   end
 
   # Enable server timing

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,15 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  show_error_pages = ENV.fetch('SHOW_ERROR_PAGES', '')
+  if show_error_pages.empty?
+    # Show full error reports only for 500s
+    config.x.dwim_error_pages = true
+  elsif show_error_pages.match?(config.re_true)
+    # Show full error reports (including 404s)
+    config.consider_all_requests_local = true
+  end
+
   # Enable server timing
   config.server_timing = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,9 +19,6 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports.
-  config.consider_all_requests_local = ENV.fetch('SHOW_ERROR_PAGES', 'no').match?(config.re_false)
-
   # Enable server timing
   config.server_timing = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,8 +14,7 @@ Rails.application.configure do
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
-  # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local = false
+  # Caching is turned on.
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,8 +25,7 @@ Rails.application.configure do
     'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  # Disable caching.
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,6 @@ services:
       # DEV_SEEDS_PATH: db/seeds_dev/data
       FORCE_AUDIENCE: ${FORCE_AUDIENCE:-false}
       RAILS_DEVELOPMENT_HOSTS: ${RAILS_DEVELOPMENT_HOSTS:-people.${DOMAIN:-dev.jkldsa.com},api.${DOMAIN:-dev.jkldsa.com}}
-      SHOW_ERROR_PAGES: ${SHOW_ERROR_PAGES:-false}
 
       # ---------------------------------------------------- transition specific
       ENABLE_ADOPTION: ${ENABLE_ADOPTION:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,7 @@ services:
       # DEV_SEEDS_PATH: db/seeds_dev/data
       FORCE_AUDIENCE: ${FORCE_AUDIENCE:-false}
       RAILS_DEVELOPMENT_HOSTS: ${RAILS_DEVELOPMENT_HOSTS:-people.${DOMAIN:-dev.jkldsa.com},api.${DOMAIN:-dev.jkldsa.com}}
+      SHOW_ERROR_PAGES: ${SHOW_ERROR_PAGES}
 
       # ---------------------------------------------------- transition specific
       ENABLE_ADOPTION: ${ENABLE_ADOPTION:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,8 +116,6 @@ services:
     #   - ./bin/dev
     # command: bin/rails server -p 3000 -b 0.0.0.0
     environment: &webappenv
-      KILLPID: ${KILLPID:-no}
-
       # ------------------------------ deployment-independent mandatory ENV vars
       RAILS_ENV: development
       SUPERUSERS: "${SUPERUSERS}"
@@ -142,7 +140,7 @@ services:
       # DEV_SEEDS_PATH: db/seeds_dev/data
       FORCE_AUDIENCE: ${FORCE_AUDIENCE:-false}
       RAILS_DEVELOPMENT_HOSTS: ${RAILS_DEVELOPMENT_HOSTS:-people.${DOMAIN:-dev.jkldsa.com},api.${DOMAIN:-dev.jkldsa.com}}
-      SHOW_ERROR_PAGES: ${SHOW_ERROR_PAGES}
+      ERROR_PAGES: ${ERROR_PAGES:-mix}
 
       # ---------------------------------------------------- transition specific
       ENABLE_ADOPTION: ${ENABLE_ADOPTION:-false}

--- a/ops/roles/k8s/vars/config.yml
+++ b/ops/roles/k8s/vars/config.yml
@@ -19,7 +19,7 @@ people_config:
   # SEEDS_PATH: db/seeds/data
   # USE_LOCAL_ELEMENTS: false
   USE_LOCAL_ELEMENTS: "{{ people.use_local_elements }}"
-
+  ERROR_PAGES: "{{ people.error_pages }}"
   WSGETPEOPLE_CACHE: "{{ people.wsgetpeople_cache }}"
 
   # ---------------------------------------------------- transition specific

--- a/ops/roles/k8s/vars/main.yml
+++ b/ops/roles/k8s/vars/main.yml
@@ -66,6 +66,7 @@ people:
   enable_adoption: "{{ ENABLE_ADOPTION | default('false') }}"
   enable_api_cache: "{{ ENABLE_API_CACHE | default('true') }}"
   env: "{{ RAILS_ENV | default('production') }}"
+  error_pages: "{{ ERROR_PAGES | default('prod') }}"
   hostname: "{{ APP_HOSTNAME }}"
   image: "quay-its.epfl.ch/svc0033/people:{{ people_version }}-prod"
   isa_url: "{{ ISA_URL | default('https://isa.epfl.ch/services') }}"

--- a/ops/roles/people/tasks/run.yml
+++ b/ops/roles/people/tasks/run.yml
@@ -50,6 +50,7 @@
       # DEV_SEEDS_PATH: db/seeds_dev/data
       FORCE_AUDIENCE: "{{ FORCE_AUDIENCE | default(false) }}"
       RAILS_DEVELOPMENT_HOSTS: "{{ (people.env == 'development') | ternary(hosts.people, '') }}"
+      ERROR_PAGES: "{{ ERROR_PAGES | default('prod') }}"
 
       # ---------------------------------------------------- transition specific
       ENABLE_ADOPTION: "{{ people.enable_adoption }}"

--- a/ops/roles/people/tasks/run.yml
+++ b/ops/roles/people/tasks/run.yml
@@ -50,7 +50,6 @@
       # DEV_SEEDS_PATH: db/seeds_dev/data
       FORCE_AUDIENCE: "{{ FORCE_AUDIENCE | default(false) }}"
       RAILS_DEVELOPMENT_HOSTS: "{{ (people.env == 'development') | ternary(hosts.people, '') }}"
-      SHOW_ERROR_PAGES: "{{ SHOW_ERROR_PAGES | default('no') }}"
 
       # ---------------------------------------------------- transition specific
       ENABLE_ADOPTION: "{{ people.enable_adoption }}"


### PR DESCRIPTION
`config.consider_all_requests_local` has the drawback of not being able to distinguish between 40x errors (for which we want the normal error page shown), from 500s (for which we want the Web debugger, but only in development).

- Override `rescue_with_handler` [documented](https://api.rubyonrails.org/v5.2/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_with_handler) method , so that we can get at the exception being processed
- Evaluate its `http_status` as per the framework configuration
- Make the decision in an overridable method, `want_web_debugger_in_dev?`. As the name implies, this method is
called only when `Rails.env.development?` is true.
- Eliminate `SHOW_ERROR_PAGES` environment variable, as it is now unused